### PR TITLE
Fix scroll issue: remove automatic scroll disabling

### DIFF
--- a/Sources/Views/ContentView.swift
+++ b/Sources/Views/ContentView.swift
@@ -75,7 +75,6 @@ struct ContentView: View {
                         .frame(maxWidth: .infinity, minHeight: geometry.size.height)
                         .frame(width: geometry.size.width)
                     }
-                    .scrollDisabled(contentFitsInScreen(geometry: geometry))
                 }
             }
             
@@ -749,13 +748,6 @@ struct ContentView: View {
                 return "\(hours)h \(remainingMinutes)m"
             }
         }
-    }
-    
-    private func contentFitsInScreen(geometry: GeometryProxy) -> Bool {
-        // Estimate content height
-        let estimatedHeight: CGFloat = 40 + 250 + 140 + 70 + 70 + 70 + 40 // header + UV + vitD + button + clothing + skin + padding
-        let offlineBarHeight: CGFloat = uvService.isOfflineMode ? 50 : 0
-        return estimatedHeight + offlineBarHeight < geometry.size.height
     }
 }
 


### PR DESCRIPTION
Fixes user complaint from https://x.com/GoranUnkovski/status/1944402844456534119 where UI suggests scrollability but prevents it, causing accidental button taps when trying to pull/scroll.

Removed `.scrollDisabled(contentFitsInScreen(geometry: geometry))` to allow consistent scrolling behavior.