### PR TITLE
Use fussier date comparison

### DIFF
--- a/Sources/Extensions/Extensions.swift
+++ b/Sources/Extensions/Extensions.swift
@@ -9,6 +9,9 @@ extension Array {
 
 extension Calendar {
     func isDateInTomorrow(_ date: Date) -> Bool {
-        return isDate(date, inSameDayAs: Date().addingTimeInterval(86400))
+        guard let tomorrow = Self.current.date(byAdding: DateComponents(day: 1), to: Date()) else {
+            return false
+        }
+        return isDate(date, inSameDayAs: tomorrow)
     }
 }


### PR DESCRIPTION
Using 86400 seconds to advance to tomorrow doesn't work in all scenarios, I've run into this on my app [Personal Best](https://apps.apple.com/gb/app/personal-best-workouts/id1510256676) WAY too many times. It works most of the time but breaks on days when the clocks go back because the day technically has 25 hours then (90000 seconds). There are probably other edge casey days too but not 100% sure.

This PR instead adds one day. Swift knows about this stuff so it'll account for daylight savings. It's less terse now though :(